### PR TITLE
refactor: use mutable entity

### DIFF
--- a/src/domain/__shared/entity/aggregate_root.py
+++ b/src/domain/__shared/entity/aggregate_root.py
@@ -8,7 +8,7 @@ from ..validator.validator_interface import ValidationResult
 from ..value_objects import ExternalEntityId, UniqueEntityId
 
 
-@dataclass(kw_only=True, slots=True, frozen=True)
+@dataclass(kw_only=True, slots=True)
 class AggregateRoot(ABC):
     """Base class for aggregate roots.
 

--- a/src/domain/customer/entity.py
+++ b/src/domain/customer/entity.py
@@ -6,7 +6,7 @@ from src.domain.__shared.validator import ValidationResult
 from src.domain.__shared.value_objects import CPF, EmailAddress
 
 
-@dataclass(kw_only=True, slots=True, frozen=True)
+@dataclass(kw_only=True, slots=True)
 class Customer(AggregateRoot):
     """Represents a customer in the system.
 

--- a/tests/domain/__shared/entity/test_aggregate_root.py
+++ b/tests/domain/__shared/entity/test_aggregate_root.py
@@ -13,7 +13,7 @@ from src.domain.__shared.validator import (
 from src.domain.__shared.value_objects import ExternalEntityId
 
 
-@dataclass(slots=True, frozen=True)
+@dataclass(slots=True)
 class StubEntity(AggregateRoot):
     def validate(self) -> ValidationResult:  # noqa: D102
         return ValidationResult(is_valid=True)
@@ -56,7 +56,7 @@ def test_aggregate_root_calls_validate() -> None:
     mock_validate.assert_called_once()
 
 
-@dataclass(kw_only=True, slots=True, frozen=True)
+@dataclass(kw_only=True, slots=True)
 class StubCustomerEntity(AggregateRoot):
     name: str
 

--- a/tests/domain/customer/test_customer_entity.py
+++ b/tests/domain/customer/test_customer_entity.py
@@ -1,4 +1,3 @@
-import dataclasses
 from datetime import datetime
 
 import pytest
@@ -16,10 +15,6 @@ def test_customer_creation_successful() -> None:
     email = EmailAddress(address="john.doe@example.com")
 
     customer = Customer(name=name, cpf=cpf, email=email)
-
-    with pytest.raises(dataclasses.FrozenInstanceError):
-        # noinspection PyDataclass
-        customer.name = "Jane Doe"
 
     assert customer.name == name
     assert customer.cpf == cpf


### PR DESCRIPTION
## Summary by Sourcery

Refactor the entity classes to be mutable by removing the 'frozen=True' attribute from their dataclass definitions, and update tests accordingly by removing checks for immutability.

Enhancements:
- Refactor entities to be mutable by removing the 'frozen=True' attribute from dataclass definitions.

Tests:
- Remove test case that checks for immutability of the Customer entity.